### PR TITLE
fix(jwtService): update API endpoints in jwtService.js and jwtService…

### DIFF
--- a/task-manager-client/src/app/auth/services/jwtService/jwtService.js
+++ b/task-manager-client/src/app/auth/services/jwtService/jwtService.js
@@ -49,7 +49,7 @@ class JwtService extends FuseUtils.EventEmitter {
 
   createUser = (data) => {
     return new Promise((resolve, reject) => {
-        axios.post('http://127.0.0.1:8090/auth/register', data).then((response) => {
+        axios.post(jwtServiceConfig.signUp, data).then((response) => {
             if (response.data.user) {
                 this.setSession(response.data.access_token);
                 resolve(response.data.user);
@@ -64,7 +64,7 @@ class JwtService extends FuseUtils.EventEmitter {
   signInWithUserAndPassword = (username, password) => {
     return new Promise((resolve, reject) => {
         axios
-            .post('http://127.0.0.1:8090/auth/login', { username, password })
+            .post(jwtServiceConfig.signIn, { username, password })
             .then((response) => {
                 if (response.data.user) {
                     this.setSession(response.data.access_token);

--- a/task-manager-client/src/app/auth/services/jwtService/jwtServiceConfig.js
+++ b/task-manager-client/src/app/auth/services/jwtService/jwtServiceConfig.js
@@ -1,6 +1,6 @@
 const jwtServiceConfig = {
-  signIn: 'api/auth/sign-in',
-  signUp: 'api/auth/sign-up',
+  signIn: 'http://127.0.0.1:8090/auth/login',
+  signUp: 'http://127.0.0.1:8090/auth/register',
   accessToken: 'api/auth/access-token',
   updateUser: 'api/auth/user/update',
 };


### PR DESCRIPTION
…Config.js

The API endpoints in jwtService.js and jwtServiceConfig.js have been updated to use the correct URLs for signing in and signing up. The previous URLs were hardcoded to 'http://127.0.0.1:8090/auth/login' and 'http://127.0.0.1:8090/auth/register' respectively. The updated URLs now use the values from jwtServiceConfig.signIn and jwtServiceConfig.signUp.